### PR TITLE
リポジトリ一覧の検索を実装

### DIFF
--- a/renderer/src/hooks/useSearchRepository.ts
+++ b/renderer/src/hooks/useSearchRepository.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { useRelayEnvironment, fetchQuery } from 'react-relay';
+import { graphql } from 'relay-runtime';
+import type { useSearchRepositoryQuery } from './__generated__/useSearchRepositoryQuery.graphql';
+
+export type Repository = {
+  name: string;
+  url: string;
+};
+
+const SearchRepositoryQuery = graphql`
+  query useSearchRepositoryQuery($query: String!) {
+    search(type: REPOSITORY, query: $query, last: 100) {
+      nodes {
+        ... on Repository {
+          name
+          url
+        }
+      }
+    }
+  }
+`;
+
+export const useSearchRepository = () => {
+  const environment = useRelayEnvironment();
+
+  const search = useCallback(
+    async (options: {
+      account: string;
+      keyword: string;
+      isOrganization: boolean;
+    }): Promise<{ name: string; url: string }[]> => {
+      return new Promise((resolve) => {
+        const accountModifier = options.isOrganization ? 'org' : 'user';
+        const query = `${options.keyword} ${accountModifier}:${options.account}`;
+        fetchQuery<useSearchRepositoryQuery>(
+          environment,
+          SearchRepositoryQuery,
+          { query: query }
+        ).subscribe({
+          next: (data) => {
+            const repositories = data.search.nodes;
+            resolve(repositories as Repository[]);
+          },
+        });
+      });
+    },
+    [environment]
+  );
+
+  return {
+    search,
+  };
+};

--- a/renderer/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
+++ b/renderer/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
@@ -10,19 +10,21 @@ import {
   containerStyle,
   iconButtonStyle,
   iconStyle,
+  repositoryLinkStyle,
   repositoryListItemStyle,
   repositoryListStyle,
   titleStyle,
 } from './styles.css';
 import { themeFocusVisibleOutline } from '../../theme.css';
+import { Repository } from '../../hooks/useSearchRepository';
 
 export const SelectRepositoryPage = () => {
   const history = useHistory();
-  const [repositories, setRepositories] = useState<string[]>([]);
+  const [repositories, setRepositories] = useState<Repository[]>([]);
   const { settings, addSubscribedRepository, removeSubscribedRepository } =
     useSettings();
 
-  const handleSearch = useCallback(async (repositories: string[]) => {
+  const handleSearch = useCallback(async (repositories: Repository[]) => {
     setRepositories(repositories);
   }, []);
 
@@ -56,7 +58,7 @@ export const SelectRepositoryPage = () => {
 };
 
 type RepositoryListProps = {
-  repositories: string[];
+  repositories: Repository[];
   subscribedRepositories: string[];
   addRepository: (repository: string) => void;
   removeRepository: (repository: string) => void;
@@ -72,11 +74,18 @@ const RepositoryList = memo<RepositoryListProps>(
     return (
       <ul className={repositoryListStyle}>
         {repositories.map((repository) => (
-          <li key={repository} className={repositoryListItemStyle}>
-            <div>{repository}</div>
-            {subscribedRepositories.includes(repository) ? (
+          <li key={repository.name} className={repositoryListItemStyle}>
+            <a
+              href={repository.url}
+              target="_blank"
+              rel="noopner noreferrer"
+              className={repositoryLinkStyle}
+            >
+              {repository.name}
+            </a>
+            {subscribedRepositories.includes(repository.name) ? (
               <button
-                onClick={() => removeRepository(repository)}
+                onClick={() => removeRepository(repository.name)}
                 className={classNames(
                   iconButtonStyle,
                   themeFocusVisibleOutline
@@ -87,7 +96,7 @@ const RepositoryList = memo<RepositoryListProps>(
               </button>
             ) : (
               <button
-                onClick={() => addRepository(repository)}
+                onClick={() => addRepository(repository.name)}
                 className={classNames(
                   iconButtonStyle,
                   themeFocusVisibleOutline

--- a/renderer/src/pages/SelectRepositoryPage/styles.css.ts
+++ b/renderer/src/pages/SelectRepositoryPage/styles.css.ts
@@ -26,6 +26,14 @@ export const repositoryListItemStyle = style({
   },
 });
 
+export const repositoryLinkStyle = style({
+  transition: 'opacity 0.1s ease-in',
+  width: '100%',
+  ':hover': {
+    opacity: 0.7,
+  },
+});
+
 export const iconButtonStyle = style({
   ':hover': {
     cursor: 'pointer',


### PR DESCRIPTION

![search](https://user-images.githubusercontent.com/11068883/130973175-03f37bad-711c-47bc-a59e-a3c4f424c301.gif)


## やったこと
- 選択されたアカウントに紐づくキーワードを含むリポジトリ一覧を検索するロジックを実装

## やってないこと
- ローディング表示などのデザインの最適化
