### PR TITLE
eslint-plugin-react の Warning 解消

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,11 @@
     "jest": true,
     "node": true
   },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",


### PR DESCRIPTION
`pnpm lint` を実行したときに、添付している画像のように Warning のメッセージが出ていたので、出ないように対応。

![スクリーンショット 2021-08-27 20 30 27](https://user-images.githubusercontent.com/13248811/131121072-5382a104-de59-4a26-a126-75c65eb530f1.png)

## やったこと
https://github.com/yannickcr/eslint-plugin-react#configuration を参考に、.eslintrc に React のバージョンを指定する設定を追加

## 確認方法
この PR で作成した *refactor/esliint-react-setting* ブランチ以外で `pnpm lint` を実行すると確認できます

## レビュー方法
- `pnpm lint` を実行してメッセージが表示されていないか確認 👀 